### PR TITLE
refactor/QUEJAS-37/Arreglo-del-despliegue-del-backend-con-la-conexion-de-la-base-de-datos

### DIFF
--- a/src/backend/pom.xml
+++ b/src/backend/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/backend/src/main/resources/application.properties
+++ b/src/backend/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=backend
 
 # ==============================
-# Conexión MySQL Railway
+# Conexión PostgreSQL
 # ==============================
-spring.datasource.url=jdbc:mysql://${MYSQLHOST}:${MYSQLPORT}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=UTC
-spring.datasource.username=${MYSQLUSER}
-spring.datasource.password=${MYSQLPASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}
+spring.datasource.username=${PGUSER}
+spring.datasource.password=${PGPASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
 
 # ==============================
 # Propiedades del RECAPTCHA
@@ -24,7 +24,7 @@ spring.datasource.hikari.max-lifetime=1800000
 # JPA / Hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # ========================================
 # NOTIFICATION SYSTEM CONFIGURATION

--- a/src/backend/src/main/resources/application.properties
+++ b/src/backend/src/main/resources/application.properties
@@ -3,9 +3,9 @@ spring.application.name=backend
 # ==============================
 # Conexión PostgreSQL
 # ==============================
-spring.datasource.url=jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}
-spring.datasource.username=${PGUSER}
-spring.datasource.password=${PGPASSWORD}
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASS}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # ==============================


### PR DESCRIPTION
El arreglo es debido a que render posee una configuración para las conexiones externas a este, por lo que necesita otras variables de entorno para conectarse a este desde afuera de render