### PR TITLE
hotfix(QUEJAS-50): Corrección de caracteres mal codificados

### DIFF
--- a/src/backend/src/main/resources/application.properties
+++ b/src/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=backend
 
 # ==============================
-# Conexión PostgreSQL
+# Conexion PostgreSQL
 # ==============================
 spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
 spring.datasource.username=${DB_USER}
@@ -29,7 +29,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 # ========================================
 # ADMIN CONFIGURATION
 # ========================================
-# Contraseña para eliminar quejas (cambiar en producción)
+# Contrasena para eliminar quejas (cambiar en produccion)
 admin.delete.password=${ADMIN_DELETE_PASSWORD}
 
 # ========================================


### PR DESCRIPTION
Se modificaron caracteres no validos en los comentarios

En aplication Properties hay caracteres que probablemente se guardaron en ISO-8859-1 o Windows-1252 en lugar de UTF-8

La ó y la ñ aparecen como � → eso es exactamente lo que provoca el MalformedInputException: Input length = 1 cuando Maven intenta procesar el archivo en UTF-8.